### PR TITLE
Upgrade embedded-hal to v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssd1327-i2c"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Hugo Eynard <hugo.eynard@gmail.com>"]
 edition = "2021"
 description = "SSD1327 I2C Driver"
@@ -21,12 +21,8 @@ categories = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = "1"
 embedded-graphics-core = { version = "0.4.0", optional = true }
-
-[dev-dependencies]
-esp-println = { version = "0.7.0", features = ["esp32"] }
-esp-backtrace = { version = "0.9.0", features = ["esp32", "panic-handler", "exception-handler", "print-uart"] }
 
 [features]
 default = ["graphics"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # SSD1327 I2C driver
-//! 
+//!
 //! `no_std` I2C Driver for SSD1327 Oled screens.
-//! 
+//!
 //! ## Example
 //! Following code shows how to flash a SSD1327 screen using the ESP HAL I2C Peripheral Driver.
 //!
@@ -15,12 +15,12 @@
 //!     100u32.kHz(),
 //!     &clocks,
 //! );
-//! 
+//!
 //! // Create a new SSD1327I2C object with slave address 0x3C, width 127 and height 127
 //! let mut driver = ssd1327_i2c::SSD1327I2C::new(i2c);
-//! 
+//!
 //! driver.init();
-//! 
+//!
 //! loop {
 //!     driver.send_cmd(ssd1327_i2c::Commands::DisplayModeAllON);
 //!     delay.delay_ms(1000u32);
@@ -30,45 +30,41 @@
 //! ```
 
 #![no_std]
-use embedded_hal;
 use core::result::Result;
+use embedded_hal;
 
 #[cfg(feature = "graphics")]
 use embedded_graphics_core::{
-    draw_target::DrawTarget, 
-    Pixel, 
-    pixelcolor::Gray4,
-    pixelcolor::GrayColor,
-    geometry::OriginDimensions, 
-    geometry::Size
+    draw_target::DrawTarget, geometry::OriginDimensions, geometry::Size, pixelcolor::Gray4,
+    pixelcolor::GrayColor, Pixel,
 };
 
 /// SSD1327 I2C driver container
 pub struct SSD1327I2C<I2C>
-where 
-    I2C: embedded_hal::blocking::i2c::Write
+where
+    I2C: embedded_hal::blocking::i2c::Write,
 {
     i2c: I2C,
-    slave_address : u8,
+    slave_address: u8,
     width: u8,
     height: u8,
     #[cfg(feature = "graphics")]
     framebuffer: [u8; 128 * 64],
 }
 
-impl <I2C> SSD1327I2C<I2C>
-where 
+impl<I2C> SSD1327I2C<I2C>
+where
     I2C: embedded_hal::blocking::i2c::Write,
 {
     /// Create a new SSD1327I2C object with custom slave adress, width and height
-    pub fn with_addr_wh(i2c : I2C, slave_address : u8, width : u8, height : u8) -> Self {
+    pub fn with_addr_wh(i2c: I2C, slave_address: u8, width: u8, height: u8) -> Self {
         #[cfg(feature = "graphics")]
         let framebuffer = [0u8; 128 * 64];
         let halfwidth = width / 2; // Two pixels per byte
         SSD1327I2C {
             i2c,
             slave_address,
-            width : halfwidth,
+            width: halfwidth,
             height,
             #[cfg(feature = "graphics")]
             framebuffer,
@@ -76,17 +72,17 @@ where
     }
 
     /// Create a new SSD1327I2C object with custom slave address, width 127 and height 127
-    pub fn with_addr(i2c : I2C, slave_address : u8) -> Self {
+    pub fn with_addr(i2c: I2C, slave_address: u8) -> Self {
         SSD1327I2C::with_addr_wh(i2c, slave_address, 0x7F, 0x7F)
     }
 
     /// Create a new SSD1327I2C object with slave address 0x3C, and custom width and height
-    pub fn with_wh(i2c : I2C, width : u8, height : u8) -> Self {
+    pub fn with_wh(i2c: I2C, width: u8, height: u8) -> Self {
         SSD1327I2C::with_addr_wh(i2c, 0x3C, width, height)
     }
 
     /// Create a new SSD1327I2C object with slave address 0x3C, width 127 and height 127
-    pub fn new(i2c : I2C) -> Self {
+    pub fn new(i2c: I2C) -> Self {
         SSD1327I2C::with_addr_wh(i2c, 0x3C, 0x7F, 0x7F)
     }
 
@@ -94,8 +90,16 @@ where
     pub fn init(&mut self) {
         self.send_cmd(Commands::CommandUnlock).ok();
         self.send_cmd(Commands::DisplayOFF).ok();
-        self.send_cmd(Commands::ColumnAddress { start: 0x00, end: self.width }).ok();
-        self.send_cmd(Commands::RowAddress { start: 0x00, end: self.height }).ok();
+        self.send_cmd(Commands::ColumnAddress {
+            start: 0x00,
+            end: self.width,
+        })
+        .ok();
+        self.send_cmd(Commands::RowAddress {
+            start: 0x00,
+            end: self.height,
+        })
+        .ok();
         self.send_cmd(Commands::ContrastControl(0x7f)).ok(); //50% (128/255) RESET 0x7f
         self.send_cmd(Commands::Remap(0x51)).ok();
         self.send_cmd(Commands::DisplayStartLine(0x00)).ok();
@@ -104,7 +108,8 @@ where
         self.send_cmd(Commands::MUXRatio(0x7e)).ok(); // RESET 0x7f
         self.send_cmd(Commands::PhaseLength(0x51)).ok(); // RESET 0x71
         self.send_cmd(Commands::LinearLUT).ok();
-        self.send_cmd(Commands::FrontClockDividerOscillatorFrequency(0x00)).ok();
+        self.send_cmd(Commands::FrontClockDividerOscillatorFrequency(0x00))
+            .ok();
         self.send_cmd(Commands::SelectInternalVDD).ok();
         self.send_cmd(Commands::SecondPreChargePeriod(0x04)).ok();
         self.send_cmd(Commands::VCOMH(0x05)).ok();
@@ -157,26 +162,28 @@ where
     pub fn send_data(&mut self, data: &[u8]) -> Result<(), I2C::Error> {
         // 0x40 = Data
         let (data, len) = (
-            [0x40, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]],
-            9
+            [
+                0x40, data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+            ],
+            9,
         );
         self.send_bytes(&data[0..len])
     }
 
     #[cfg(feature = "graphics")]
     /// Write 8 bytes of data to the SSD1327
-    fn send_buffer_data(&mut self, index : usize) -> Result<(), I2C::Error> {
+    fn send_buffer_data(&mut self, index: usize) -> Result<(), I2C::Error> {
         // 0x40 = Data
         let bytes = [
-            0x40, 
-            self.framebuffer[index], 
-            self.framebuffer[index + 1], 
-            self.framebuffer[index + 2], 
-            self.framebuffer[index + 3], 
-            self.framebuffer[index + 4], 
-            self.framebuffer[index + 5], 
-            self.framebuffer[index + 6], 
-            self.framebuffer[index + 7]
+            0x40,
+            self.framebuffer[index],
+            self.framebuffer[index + 1],
+            self.framebuffer[index + 2],
+            self.framebuffer[index + 3],
+            self.framebuffer[index + 4],
+            self.framebuffer[index + 5],
+            self.framebuffer[index + 6],
+            self.framebuffer[index + 7],
         ];
         self.send_bytes(&bytes)
     }
@@ -184,9 +191,17 @@ where
     #[cfg(feature = "graphics")]
     /// Update the display with the current framebuffer
     pub fn flush(&mut self) -> Result<(), I2C::Error> {
-        self.send_cmd(Commands::ColumnAddress { start: 0x00, end: self.width }).ok(); //0-63
-        self.send_cmd(Commands::RowAddress { start: 0x00, end: self.height }).ok(); //0-127
-        let mut res : Result<(), I2C::Error> = Ok(());
+        self.send_cmd(Commands::ColumnAddress {
+            start: 0x00,
+            end: self.width,
+        })
+        .ok(); //0-63
+        self.send_cmd(Commands::RowAddress {
+            start: 0x00,
+            end: self.height,
+        })
+        .ok(); //0-127
+        let mut res: Result<(), I2C::Error> = Ok(());
         for y in 0..=127 {
             for x in (0..=63).step_by(8) {
                 match self.send_buffer_data(x + y * 64) {
@@ -197,26 +212,25 @@ where
         }
         res
     }
-    
 }
 
 /// Commands to be sent to the SSD1327
 pub enum Commands {
     /// Setup Column start and end address (0x15)
     ColumnAddress {
-        /// Start address 00-7f (RESET = 00) 
+        /// Start address 00-7f (RESET = 00)
         start: u8,
-        /// End address 00-3f (RESET = 3F) 
+        /// End address 00-3f (RESET = 3F)
         end: u8,
     },
     /// Setup Row start and end address (0x75)
     RowAddress {
-        /// Start address 00-7f (RESET = 00) 
+        /// Start address 00-7f (RESET = 00)
         start: u8,
-        /// End address 00-7f (RESET = 7F) 
+        /// End address 00-7f (RESET = 7F)
         end: u8,
     },
-    /// Double byte command to select 1 out of 256 contrast steps. 
+    /// Double byte command to select 1 out of 256 contrast steps.
     /// Contrast increases as the value increases (RESET = 7F ) (0x81)
     ContrastControl(u8),
     /// **Re-map setting in Graphic Display Data RAM (GDDRAM)** (0xA0)\
@@ -232,7 +246,7 @@ pub enum Commands {
     /// A[5] = 0, Reserved (RESET)\
     /// A[6] = 0, Disable COM Split Odd Even (RESET)\
     /// A[6] = 1, Enable COM Split Odd Even\
-    /// A[7] = 0, Reserved (RESET) 
+    /// A[7] = 0, Reserved (RESET)
     Remap(u8),
     /// Vertical shift by setting the starting address of display RAM from 0 ~ 127 (RESET = 00) (0xA1)
     DisplayStartLine(u8),
@@ -262,8 +276,8 @@ pub enum Commands {
     PhaseLength(u8),
     /// Front Clock Divider / Oscillator Frequency (0xB3)
     FrontClockDividerOscillatorFrequency(u8),
-    /// GPIO : 00 represents GPIO pin HiZ, input disable (always read as low) ; 
-    /// 01 represents GPIO pin HiZ, input enable ; 10 represents GPIO pin output Low (RESET) ; 
+    /// GPIO : 00 represents GPIO pin HiZ, input disable (always read as low) ;
+    /// 01 represents GPIO pin HiZ, input enable ; 10 represents GPIO pin output Low (RESET) ;
     /// 11 represents GPIO pin output High ; (0xB5)
     GPIO(u8),
     /// Second Pre-charge period of 1~15 DCLK’s (RESET = 0100) (0xB6)
@@ -274,7 +288,7 @@ pub enum Commands {
     PreChargeVoltage(u8),
     /// Set COM deselect voltage level (0xBE)
     VCOMH(u8),
-    /// Function Selection B : 0.: Disable second precharge (RESET) ; 1.: Enable second precharge ; 
+    /// Function Selection B : 0.: Disable second precharge (RESET) ; 1.: Enable second precharge ;
     /// .0: Internal VSL (RESET) ; .1: Enable external VSL ; (0xD5)
     FunctionSelectionB(u8),
     /// MCU protection status 0x16 = Lock ; 0x12 Unlock (RESET) ; (0xFD)
@@ -286,11 +300,10 @@ pub enum Commands {
 }
 
 #[cfg(feature = "graphics")]
-impl <I2C> DrawTarget for SSD1327I2C<I2C>
-where 
-    I2C: embedded_hal::blocking::i2c::Write 
+impl<I2C> DrawTarget for SSD1327I2C<I2C>
+where
+    I2C: embedded_hal::blocking::i2c::Write,
 {
-
     type Color = Gray4;
 
     type Error = I2C::Error;
@@ -303,7 +316,7 @@ where
             // Check if the pixel coordinates are out of bounds
             if let Ok((x @ 0..=127, y @ 0..=127)) = coord.try_into() {
                 // Calculate the index in the framebuffer.
-                let index: u32 = x/2 + y * 64;
+                let index: u32 = x / 2 + y * 64;
                 let mut new_byte = color.luma();
                 // 1 byte for 2 pixels so we need to shift the byte by 4 bits if the x coordinate is even
                 if x % 2 == 0 {
@@ -318,13 +331,12 @@ where
 
         Ok(())
     }
-
 }
 
 #[cfg(feature = "graphics")]
-impl <I2C> OriginDimensions for SSD1327I2C<I2C>
-where 
-    I2C: embedded_hal::blocking::i2c::Write
+impl<I2C> OriginDimensions for SSD1327I2C<I2C>
+where
+    I2C: embedded_hal::blocking::i2c::Write,
 {
     fn size(&self) -> Size {
         Size::new(self.width as u32, self.height as u32)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ use embedded_graphics_core::{
 /// SSD1327 I2C driver container
 pub struct SSD1327I2C<I2C>
 where
-    I2C: embedded_hal::blocking::i2c::Write,
+    I2C: embedded_hal::i2c::I2c,
 {
     i2c: I2C,
     slave_address: u8,
@@ -54,7 +54,7 @@ where
 
 impl<I2C> SSD1327I2C<I2C>
 where
-    I2C: embedded_hal::blocking::i2c::Write,
+    I2C: embedded_hal::i2c::I2c,
 {
     /// Create a new SSD1327I2C object with custom slave adress, width and height
     pub fn with_addr_wh(i2c: I2C, slave_address: u8, width: u8, height: u8) -> Self {
@@ -302,7 +302,7 @@ pub enum Commands {
 #[cfg(feature = "graphics")]
 impl<I2C> DrawTarget for SSD1327I2C<I2C>
 where
-    I2C: embedded_hal::blocking::i2c::Write,
+    I2C: embedded_hal::i2c::I2c,
 {
     type Color = Gray4;
 
@@ -336,7 +336,7 @@ where
 #[cfg(feature = "graphics")]
 impl<I2C> OriginDimensions for SSD1327I2C<I2C>
 where
-    I2C: embedded_hal::blocking::i2c::Write,
+    I2C: embedded_hal::i2c::I2c,
 {
     fn size(&self) -> Size {
         Size::new(self.width as u32, self.height as u32)


### PR DESCRIPTION
As per the title, upgrades to the stable release of `embedded-hal` as per the [migration guide](https://github.com/rust-embedded/embedded-hal/blob/master/docs/migrating-from-0.2-to-1.0.md). Tested on an atmega32u4.

In addition, also ran `cargo fmt` on the code before editing. I recommend looking at the commits individually. Please let me know if you prefer not to use `cargo fmt` for this repository.